### PR TITLE
Directly apply `ipiv` permutation from `LU` without `Base.permute!!`

### DIFF
--- a/src/NonlinearSystems.jl
+++ b/src/NonlinearSystems.jl
@@ -1,6 +1,6 @@
 module NonlinearSystems
 
-using Base: RefValue, Fix1, permute!!
+using Base: RefValue, Fix1
 using CommonSolve: solve
 using FastLapackInterface: LUWs
 using LinearAlgebra: BLAS, LAPACK, LU, Cholesky, cholesky!, Hermitian, ldiv!, mul!,

--- a/src/linsolve.jl
+++ b/src/linsolve.jl
@@ -1,21 +1,15 @@
 const PFac = PositiveFactorizations
 
-# A non-allocating version of ipiv2perm from LinearAlgebra/src/lu.jl
-function ipiv2perm!(p::AbstractVector{T}, v::AbstractVector{T}, maxi::Integer) where T
-    length(p) == maxi || throw(DimensionMismatch("length of p must be $maxi"))
-    @inbounds for i in 1:maxi
-        p[i] = i
-    end
+function apply_ipiv_perm!(w::AbstractVector, v::AbstractVector{<:Integer})
     @inbounds for i in eachindex(v)
-        p[i], p[v[i]] = p[v[i]], p[i]
+        w[i], w[v[i]] = w[v[i]], w[i]
     end
-    return p
+    return w
 end
 
 function luupdate!(lu::LU, p::AbstractVector, w::AbstractVector, v::AbstractVector)
     m, n = size(lu)
-    ipiv2perm!(p, getfield(lu, :ipiv), m)
-    permute!!(w, p)
+    apply_ipiv_perm!(w, getfield(lu, :ipiv), m)
     F = getfield(lu, :factors)
     @inbounds for i in 1:min(m, n)
         wi = w[i]

--- a/test/linsolve.jl
+++ b/test/linsolve.jl
@@ -20,8 +20,7 @@ end
         v = rand(N)
         f = lu(A)
         A1 = A + w * v'
-        p = zeros(Int, N)
-        f1 = luupdate!(f, p, w, v)
+        f1 = luupdate!(f, w, v)
         LU1 = f1.L * f1.U
         PA1 = f.P * A1
         @test PA1 ≈ LU1


### PR DESCRIPTION
`Base.permute!!` is undocumented and therefore internal and not subject to SymVer (e.g. it may be removed in Julia 1.10). It also has performance issues (see: ...)

This PR replaces the usage of `permute!!` with a simpler and more efficient alternative.

Here's some benchmarks I used to get an idea of the performance change

```julia
# Before
function ipiv2perm!(p::AbstractVector{T}, v::AbstractVector{T}, maxi::Integer) where T
    length(p) == maxi || throw(DimensionMismatch("length of p must be $maxi"))
    @inbounds for i in 1:maxi
        p[i] = i
    end
    @inbounds for i in eachindex(v)
        p[i], p[v[i]] = p[v[i]], p[i]
    end
    return p
end

function luupdate1!(ipiv, p::AbstractVector, w::AbstractVector, v::AbstractVector)
    m = length(ipiv)
    ipiv2perm!(p, ipiv, m)
    Base.permute!!(w, p)
end

# After
function apply_ipiv_perm!(w::AbstractVector, v::AbstractVector{<:Integer})
    @inbounds for i in eachindex(v)
        w[i], w[v[i]] = w[v[i]], w[i]
    end
    return w
end

function luupdate2!(ipiv, p::AbstractVector, w::AbstractVector, v::AbstractVector)
    m = length(ipiv)
    apply_ipiv_perm!(w, ipiv)
end

using BenchmarkTools
for T in (Float64, big(0):big(10)^100)
    println()
    println("T = $T")
    for n in [5, 10, 100, 1000, 100_000]
        println("n = $n")
        print("Before:"); @btime luupdate1!(ipiv, p, w, v) setup=(ipiv=rand(1:$n, $n); p=copy(ipiv); w=rand($T, $n); v=rand($T, $n))
        print("After: "); @btime luupdate2!(ipiv, p, w, v) setup=(ipiv=rand(1:$n, $n); p=copy(ipiv); w=rand($T, $n); v=rand($T, $n))
    end
end
```
Results
```
T = Float64
n = 5
Before:  10.636 ns (0 allocations: 0 bytes)
After:   4.083 ns (0 allocations: 0 bytes)
n = 10
Before:  17.846 ns (0 allocations: 0 bytes)
After:   8.209 ns (0 allocations: 0 bytes)
n = 100
Before:  160.579 ns (0 allocations: 0 bytes)
After:   52.622 ns (0 allocations: 0 bytes)
n = 1000
Before:  3.412 μs (0 allocations: 0 bytes)
After:   498.495 ns (0 allocations: 0 bytes)
n = 100000
Before:  814.292 μs (0 allocations: 0 bytes)
After:   112.250 μs (0 allocations: 0 bytes)

T = 0:10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
n = 5
Before:  14.112 ns (0 allocations: 0 bytes)
After:   8.842 ns (0 allocations: 0 bytes)
n = 10
Before:  24.096 ns (0 allocations: 0 bytes)
After:   15.990 ns (0 allocations: 0 bytes)
n = 100
Before:  205.332 ns (0 allocations: 0 bytes)
After:   144.407 ns (0 allocations: 0 bytes)
n = 1000
Before:  3.589 μs (0 allocations: 0 bytes)
After:   1.429 μs (0 allocations: 0 bytes)
n = 100000
Before:  830.625 μs (0 allocations: 0 bytes)
After:   228.667 μs (0 allocations: 0 bytes)
```