### PR TITLE
Fix issues with `DenseCholeskySolver`

### DIFF
--- a/src/linsolve.jl
+++ b/src/linsolve.jl
@@ -40,8 +40,8 @@ mutable struct DenseLUSolver{F}
 end
 
 default_linsolver(fdf::OnceDifferentiable{V, M, V}, x0::V,
-    ::Type{RootFinding}) where {V<:AbstractVector, M<:AbstractMatrix} =
-        init(DenseLUSolver, fdf, x0)
+    ::Type{RootFinding}; kwargs...) where {V<:AbstractVector, M<:AbstractMatrix} =
+        init(DenseLUSolver, fdf, x0; kwargs...)
 
 init(::Type{DenseLUSolver}, fdf::OnceDifferentiable, x0::AbstractVector;
     initf::Bool=true, initdf::Bool=true) =
@@ -143,19 +143,19 @@ mutable struct DenseCholeskySolver{TF, TI, M, V, V1<:Union{V,Nothing}}
 end
 
 default_linsolver(fdf::OnceDifferentiable{V, M, V}, x0::V,
-    ::Type{LeastSquares}) where {V<:AbstractVector, M<:AbstractMatrix} =
-        init(DenseCholeskySolver, fdf, x0)
+    ::Type{LeastSquares}; kwargs...) where {V<:AbstractVector, M<:AbstractMatrix} =
+        init(DenseCholeskySolver, fdf, x0; kwargs...)
 
 init(::Type{DenseCholeskySolver}, fdf::OnceDifferentiable, x0::AbstractVector;
     initf::Bool=true, initdf::Bool=true, kwargs...) =
         (_init!(fdf, x0, initf, initdf); init(DenseCholeskySolver, fdf.DF, fdf.F; kwargs...))
 
 function init(::Type{DenseCholeskySolver}, J::AbstractMatrix, f::AbstractVector;
-        rank1chol::Bool=length(f)>3)
+        rank1update::Val{R}=Val(true)) where R
     JtJ = J'J
     Jtf = J'f
-    d = Vector{PFac.signtype(eltype(J))}(undef, size(J, 1))
-    if rank1chol
+    d = Vector{PFac.signtype(eltype(J))}(undef, size(J, 2))
+    if R == true
         v1, v2 = similar(Jtf), similar(Jtf)
         return DenseCholeskySolver(JtJ, Jtf, v1, v2, d, _cholesky!(JtJ, d))
     else

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -22,7 +22,7 @@ using PrecompileTools: @setup_workload, @compile_workload
         solve(Hybrid, p1_f!, x0_1)
         solve(Hybrid, p15_f!, x0_15, thres_jac=0)
         solve(Hybrid{LeastSquares}, fdf, x0_1;
-            linsolver=init(DenseCholeskySolver, fdf, x0_1; rank1chol=false))
+            linsolver=init(DenseCholeskySolver, fdf, x0_1; rank1update=Val(true)))
         solve(Hybrid{LeastSquares}, p15_f!, x0_15, thres_jac=0)
     end
 end

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -56,8 +56,8 @@
     p2 = solve(Hybrid{LeastSquares}(), f!, j!, x0)
     @test Symbol(getexitstate(p2)) === :ftol_reached
     @test sprint(show, p2)[1:46] == "2×2 NonlinearSystem{LeastSquares}(Hybrid, 9.8"
-    @test sprint(show, MIME("text/plain"), p2)[1:329] == """
-        2×2 NonlinearSystem{LeastSquares, Vector{Float64}, Matrix{Float64}, HybridSolver{Float64, DenseCholeskySolver{Float64, Int8, Matrix{Float64}, Vector{Float64}, Nothing}, Vector{Float64}}, Nothing, Nothing}:
+    @test sprint(show, MIME("text/plain"), p2)[1:337] == """
+        2×2 NonlinearSystem{LeastSquares, Vector{Float64}, Matrix{Float64}, HybridSolver{Float64, DenseCholeskySolver{Float64, Int8, Matrix{Float64}, Vector{Float64}, Vector{Float64}}, Vector{Float64}}, Nothing, Nothing}:
           Problem type:                 Least squares
           Algorithm:                    Hybrid
           Candidate (x):                [1.04"""

--- a/test/linsolve.jl
+++ b/test/linsolve.jl
@@ -53,7 +53,7 @@ end
 @testset "DenseCholeskySolver" begin
     x0 = zeros(2)
     fdf = OnceDifferentiable(f!, j!, x0, similar(x0))
-    s = default_linsolver(fdf, x0, LeastSquares)
+    s = default_linsolver(fdf, x0, LeastSquares; rank1update=Val(false))
     @test typeof(s).parameters[5] === Nothing
     Y = zeros(2)
     J = fdf.DF


### PR DESCRIPTION
The option for setting the use of rank-1 update caused type ambiguity issues. Rank-1 update for Cholesky decomposition is now used by default.